### PR TITLE
Remove patchlevel specification in RVMRC

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm ruby-1.9.2-p0@metrics
+rvm ruby-1.9.2@metrics


### PR DESCRIPTION
Don't need to be so specific (I don't use that version of 1.9.2).

See: http://ryan.mcgeary.org/2011/02/09/vendor-everything-still-applies/
