### PR TITLE
Refactoring agents and instrument type methods

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,9 @@ RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
 end
 
+RSpec::Core::RakeTask.new(:spec_docs) do |t|
+  t.rspec_opts = ["-c", "-f documentation", "-r ./spec/spec_helper.rb"]
+  t.pattern = 'spec/**/*_spec.rb'
+end
+
 task :default => :spec

--- a/examples/timer.rb
+++ b/examples/timer.rb
@@ -10,7 +10,10 @@ timer.update(500,   :milliseconds)
 timer.update(5,     :seconds)
 timer.update(4242,  :nanoseconds)
 
-msec_timer = @metrics.timer :msec_timer, {:duration_unit => :microseconds, :rate_unit => :seconds}
+msec_timer = @metrics.timer :msec_timer do |t| 
+  t.duration_unit = :microseconds
+  t.rate_unit = :seconds
+end
 
 step = 0
 

--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -25,7 +25,7 @@ end
 module Metrics
   class Agent
     include Logging
-    include Instruments::TypeMethods
+    include Instruments::Instrumentation
     
     attr_reader :instruments
     
@@ -38,7 +38,7 @@ module Metrics
     def start
       start_daemon_thread
     end
-    
+      
     protected
     def start_daemon_thread(connection_options = {})
       logger.debug "Creating Metrics daemon thread."

--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -27,7 +27,7 @@ module Metrics
     include Logging
     include Instruments::Instrumentation
     
-    attr_reader :instruments
+    attr_reader :instruments, :port
     
     def initialize(port = 8001)
       logger.debug "Initializing Metrics..."

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -13,6 +13,7 @@ require 'json'
 
 module Metrics
   module Instruments
+
     @instruments = {}
     
     @types = {
@@ -34,39 +35,28 @@ module Metrics
     def self.registered
       @instruments
     end
+
+    def self.instruments
+      @types.keys
+    end
     
     def self.to_json
       @instruments.to_json 
     end
-    
-    module TypeMethods
-      
-      def register(type, name, &block)
-        Metrics::Instruments.register(type, name, &block)
+
+    module Instrumentation
+
+      Metrics::Instruments.instruments.each do |instrument|
+
+        define_method(instrument) do |name, &block|
+          Metrics::Instruments.register(instrument, name, &block)
+        end
+
       end
-      
-      def counter(name)
-        register(:counter, name)
-      end
-      
-      def meter(name)
-        register(:meter, name)
-      end
-      
-      def gauge(name, &block)
-        register(:gauge, name, &block)
-      end
-      
-      def uniform_histogram(name)
-        register(:uniform_histogram, name)
-      end
-      
+
       # For backwards compatibility
       alias_method :histogram, :uniform_histogram
-      
-      def exponential_histogram(name)
-        register(:exponential_histogram, name)
-      end
+    
     end
     
   end

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -36,8 +36,8 @@ module Metrics
       @instruments
     end
 
-    def self.instruments
-      @types.keys
+    def self.types
+      @types
     end
     
     def self.to_json
@@ -46,7 +46,7 @@ module Metrics
 
     module Instrumentation
 
-      Metrics::Instruments.instruments.each do |instrument|
+      Metrics::Instruments.types.each do |instrument, klass|
 
         define_method(instrument) do |name, &block|
           Metrics::Instruments.register(instrument, name, &block)

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -10,6 +10,7 @@ require File.join(File.dirname(__FILE__), 'instruments', 'meter')
 require File.join(File.dirname(__FILE__), 'instruments', 'gauge')
 require File.join(File.dirname(__FILE__), 'instruments', 'histogram')
 require File.join(File.dirname(__FILE__), 'instruments', 'timer')
+require File.join(File.dirname(__FILE__), 'instruments', 'calibration')
 
 
 require 'json'

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -41,7 +41,7 @@ module Metrics
     end
     
     def self.to_json
-      @instruments.to_json 
+      registered.to_json 
     end
 
     module Instrumentation

--- a/lib/ruby-metrics/instruments/calibration.rb
+++ b/lib/ruby-metrics/instruments/calibration.rb
@@ -4,8 +4,8 @@ module Metrics
 
       attr_accessor :duration_unit, :rate_unit
 
-      def initialize
-        @duration_unit = @rate_unit = :seconds
+      def initialize(units)
+        @duration_unit = @rate_unit = units
       end
 
       def calibrate(calibration)

--- a/lib/ruby-metrics/instruments/calibration.rb
+++ b/lib/ruby-metrics/instruments/calibration.rb
@@ -8,6 +8,16 @@ module Metrics
         @duration_unit = @rate_unit = :seconds
       end
 
+      def calibrate(calibration)
+        [:duration_unit, :rate_unit].each do |parameter|
+          if calibration.respond_to?(parameter)
+            writer = parameter.to_s + '='
+            value = calibration.send(parameter)
+            self.send(writer, value)
+          end
+        end
+      end
+
     end
   end
 end

--- a/lib/ruby-metrics/instruments/calibration.rb
+++ b/lib/ruby-metrics/instruments/calibration.rb
@@ -1,0 +1,13 @@
+module Metrics
+  module Instruments
+    class Calibration
+
+      attr_accessor :duration_unit, :rate_unit
+
+      def initialize
+        @duration_unit = @rate_unit = :seconds
+      end
+
+    end
+  end
+end

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -12,10 +12,14 @@ module Metrics
       FIVE_MINUTE_FACTOR    = 1 - Math.exp(-INTERVAL / (60.0 * 5.0))
       FIFTEEN_MINUTE_FACTOR = 1 - Math.exp(-INTERVAL / (60.0 * 15.0))
       
-      attr_reader :count
+      attr_reader :count, :calibration
       alias_method :counted, :count
       
-      def initialize(options = {})
+      def initialize
+        @calibration = Calibration.new
+
+        yield calibration if block_given?
+
         @one_minute_rate = @five_minute_rate = @fifteen_minute_rate = 0.0
         @count  = 0
         @initialized = false
@@ -62,25 +66,29 @@ module Metrics
         @count = 0
       end
       
-      def one_minute_rate(rate_unit = :seconds)
-        convert_to_ns @one_minute_rate, rate_unit
+      def one_minute_rate(rate_unit = nil)
+        unit = rate_unit || calibration.rate_unit
+        convert_to_ns @one_minute_rate, unit 
       end
       
-      def five_minute_rate(rate_unit = :seconds)
-        convert_to_ns @five_minute_rate, rate_unit
+      def five_minute_rate(rate_unit = nil)
+        unit = rate_unit || calibration.rate_unit
+        convert_to_ns @five_minute_rate, unit
       end
       
-      def fifteen_minute_rate(rate_unit = :seconds)
-        convert_to_ns @fifteen_minute_rate, rate_unit
+      def fifteen_minute_rate(rate_unit = nil)
+        unit = rate_unit || calibration.rate_unit
+        convert_to_ns @fifteen_minute_rate, unit
       end
       
-      def mean_rate(rate_unit = seconds)
+      def mean_rate(rate_unit = nil)
+        unit = rate_unit || calibration.rate_unit
         count = @count
         if count == 0
           return 0.0;
         else
           elapsed = Time.now.to_f - @start_time.to_f
-          convert_to_ns (count.to_f / elapsed.to_f), rate_unit
+          convert_to_ns (count.to_f / elapsed.to_f), unit
         end
       end
       

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -16,7 +16,7 @@ module Metrics
       alias_method :counted, :count
       
       def initialize
-        @calibration = Calibration.new
+        @calibration = Calibration.new(:seconds)
 
         yield calibration if block_given?
 

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -5,14 +5,16 @@ module Metrics
     class Timer < Base
       include Metrics::TimeConversion 
       
-      attr_reader :duration_unit, :rate_unit
+      attr_accessor :duration_unit, :rate_unit
       
-      def initialize(options = {})
+      def initialize
         @meter          = Meter.new
         @histogram      = ExponentialHistogram.new
 
-        @duration_unit  = options[:duration_unit] || :seconds
-        @rate_unit      = options[:rate_unit] || :seconds
+        yield self if block_given?
+
+        @duration_unit ||= :seconds
+        @rate_unit     ||= :seconds
         
         clear
       end

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -8,7 +8,7 @@ module Metrics
       attr_reader :calibration
       
       def initialize
-        @calibration = Calibration.new
+        @calibration = Calibration.new(:seconds)
 
         yield calibration if block_given?
 

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -70,7 +70,7 @@ describe Metrics::Agent do
     WEBrick::HTTPServer.should_receive(:new).and_return mock_server
     mock_server.should_receive(:mount)
     mock_server.should_receive(:start)
-    @agent.start
+    subject.start
   end
     
 end

--- a/spec/instruments/calibration_spec.rb
+++ b/spec/instruments/calibration_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 describe Metrics::Instruments::Calibration do
 
+  subject { Metrics::Instruments::Calibration.new(:units) }
+
   describe '#new' do
 
-    its(:duration_unit) { should equal(:seconds) }
-    its(:rate_unit)     { should equal(:seconds) }
+    context 'given a unit :units' do
+
+      its(:duration_unit) { should equal(:units) }
+      its(:rate_unit)     { should equal(:units) }
+
+    end
 
   end
 
@@ -13,7 +19,7 @@ describe Metrics::Instruments::Calibration do
 
     context 'given another calibration' do
 
-      let(:calibration) { Metrics::Instruments::Calibration.new }
+      let(:calibration) { Metrics::Instruments::Calibration.new(:units) }
 
       before(:all) do
         calibration.duration_unit = :fake_units
@@ -23,13 +29,13 @@ describe Metrics::Instruments::Calibration do
       it "sets its duration unit to the given calibration's duration unit" do
         expect {
           subject.calibrate(calibration)
-        }.to change(subject, :duration_unit).from(:seconds).to(:fake_units)
+        }.to change(subject, :duration_unit).to(:fake_units)
       end
 
       it "sets its rate unit to the given calibration's rate unit" do
         expect {
           subject.calibrate(calibration)
-        }.to change(subject, :rate_unit).from(:seconds).to(:fake_units)
+        }.to change(subject, :rate_unit).to(:fake_units)
       end
 
     end

--- a/spec/instruments/calibration_spec.rb
+++ b/spec/instruments/calibration_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Metrics::Instruments::Calibration do
+
+  describe '#new' do
+
+    its(:duration_unit) { should equal(:seconds) }
+    its(:rate_unit)     { should equal(:seconds) }
+
+  end
+
+end

--- a/spec/instruments/calibration_spec.rb
+++ b/spec/instruments/calibration_spec.rb
@@ -9,4 +9,31 @@ describe Metrics::Instruments::Calibration do
 
   end
 
+  describe '#calibrate' do
+
+    context 'given another calibration' do
+
+      let(:calibration) { Metrics::Instruments::Calibration.new }
+
+      before(:all) do
+        calibration.duration_unit = :fake_units
+        calibration.rate_unit = :fake_units
+      end
+
+      it "sets its duration unit to the given calibration's duration unit" do
+        expect {
+          subject.calibrate(calibration)
+        }.to change(subject, :duration_unit).from(:seconds).to(:fake_units)
+      end
+
+      it "sets its rate unit to the given calibration's rate unit" do
+        expect {
+          subject.calibrate(calibration)
+        }.to change(subject, :rate_unit).from(:seconds).to(:fake_units)
+      end
+
+    end
+
+  end
+
 end

--- a/spec/instruments/timer_spec.rb
+++ b/spec/instruments/timer_spec.rb
@@ -56,7 +56,10 @@ describe Metrics::Instruments::Timer do
   
   context "Timing some events" do
     before(:each) do
-      @timer = Metrics::Instruments::Timer.new({:duration_unit => :milliseconds, :rate_unit => :seconds})
+      @timer = Metrics::Instruments::Timer.new do |t|
+        t.duration_unit = :milliseconds 
+        t.rate_unit = :seconds
+      end
       @timer.update(10, :milliseconds)
       @timer.update(20, :milliseconds)
       @timer.update(20, :milliseconds)
@@ -99,7 +102,10 @@ describe Metrics::Instruments::Timer do
   
   context "Timing blocks of code" do
     before(:each) do
-      @timer = Metrics::Instruments::Timer.new({:duration_unit => :nanoseconds, :rate_unit => :nanoseconds})
+      @timer = Metrics::Instruments::Timer.new do |t|
+        t.duration_unit = :nanoseconds 
+        t.rate_unit = :nanoseconds
+      end
     end
     
     it "should return the result of the block passed" do       

--- a/spec/instruments_spec.rb
+++ b/spec/instruments_spec.rb
@@ -1,62 +1,96 @@
 require 'spec_helper'
 
 describe Metrics::Instruments do
+
+  subject { Metrics::Instruments }
+
   before(:each) do
-    @instruments = Metrics::Instruments
-    @instruments.unregister_all
-    
-    @counter = Metrics::Instruments::Counter.new
-    @meter = Metrics::Instruments::Meter.new
-  end
-  
-  it "should initially have no instruments in its hash" do
-    @instruments.registered.should == {}
-  end
-  
-  it "should allow for registering a Counter instrument" do
-    Metrics::Instruments::Counter.stub!(:new).and_return @counter
-    @instruments.register(:counter, :test_counter).should == @counter
-    @instruments.registered.should == {:test_counter => @counter}
-  end
-  
-  it "should allow for registering a Meter instrument" do
-    Metrics::Instruments::Meter.stub!(:new).and_return @meter
-    @instruments.register(:meter, :test_meter).should == @meter
-    @instruments.registered.should == {:test_meter => @meter}
+    subject.unregister_all
   end
 
-  it "should allow for registering a Histogram instrument using uniform sampling" do
-    histogram = Metrics::Instruments::UniformHistogram.new
-    Metrics::Instruments::UniformHistogram.stub!(:new).and_return histogram
-    @instruments.register(:uniform_histogram, :test_histogram).should == histogram
-    @instruments.registered.should == {:test_histogram => histogram}
+  context 'initially' do
+
+    it 'should have no registered instruments' do
+      subject.registered.should be_empty
+    end
+
   end
 
-  it "should allow for registering a Histogram instrument using exponentially decaying sampling" do
-    histogram = Metrics::Instruments::ExponentialHistogram.new
-    Metrics::Instruments::ExponentialHistogram.stub!(:new).and_return histogram
-    @instruments.register(:exponential_histogram, :test_histogram).should == histogram
-    @instruments.registered.should == {:test_histogram => histogram}
+  describe '.register' do
+
+    Metrics::Instruments.types.each do |instrument, instrument_class|
+
+      context "given :#{instrument}, a name, and a block" do
+
+        let(:name) { :test }
+        let(:block) { Proc.new { :block } }
+
+        it "should return a new #{instrument_class}" do
+          subject.register(instrument, name, &block).
+            should be_a(instrument_class)
+        end
+
+        it "should register a new #{instrument_class} under the given name" do
+          test_instrument = double(instrument_class)
+          instrument_class.stub!(:new).and_return(test_instrument)
+
+          subject.register(instrument, name, &block)
+          subject.registered[name].should eql(test_instrument)
+        end
+        
+      end
+
+    end
+
   end
 
-  
-  it "should generate JSON correctly" do 
-    Metrics::Instruments::Meter.stub!(:new).and_return @meter
-    @instruments.register(:meter, :test_meter).should == @meter
-    @instruments.registered.should == {:test_meter => @meter}
-    
-    @instruments.to_json.should == "{\"test_meter\":\"{\\\"one_minute_rate\\\":0.0,\\\"five_minute_rate\\\":0.0,\\\"fifteen_minute_rate\\\":0.0}\"}"
+  describe '.unregister_all' do
+
+    before do
+      instrument = Metrics::Instruments.types.keys.first
+      subject.register(instrument, instrument) do
+        :block
+      end
+    end
+
+    it 'should clear the registered instruments' do
+      expect {
+        subject.unregister_all
+      }.to change(subject, :registered).to({})
+    end
+
   end
-  
-  it "should not allow for creating a gauge with no block" do 
-    lambda do
-      @instruments.register :gauge, :test_gauge
-    end.should raise_error(ArgumentError)
+
+  describe '.registered' do
+
+    let(:fake_counter) { double(Metrics::Instruments::Counter) }
+
+    before do
+      Metrics::Instruments::Counter.stub!(:new).and_return(fake_counter)
+      subject.register(:counter, :test_counter)
+    end
+
+    it 'should return a Hash of registered names and instruments' do
+      subject.registered.should eql({
+        :test_counter => fake_counter
+      })
+    end
+
   end
-  
-  it "should allow for creating a gauge with a block" do 
-    proc = Proc.new { "result" }
-    @instruments.register :gauge, :test_gauge, &proc
+
+  describe '.to_json' do
+
+    let(:registered) { double(:@registered) }
+
+    before do
+      subject.stub!(:registered).and_return(registered)
+    end
+
+    it 'should return .registered JSONified' do
+      registered.should_receive(:to_json)
+      subject.to_json
+    end
+
   end
-    
+
 end


### PR DESCRIPTION
- Moves instrumentation methods to a common interface
- Cleans up Agent and Instrument specs (with nice output via `rake spec_docs`)
  - Suppresses logger output during testing
  - Tests server failure in Agent spec
- Introduces notion of `Calibration` to configure Timers and Meters
  - `Timer.new` and `Meter.new` now accept a block to set `rate_unit` and `duration_unit` (see examples/timer.rb)
## 

Some explanation:

I thought it would be nice if all `Instruments` had the same registration interface. This led me to declare all of the `TypeMethods` (now `Instrumentation`, which I thought more linguistically appealing) programmatically, based off of `Instruments.types`, and to have them register themselves with `Instruments` directly.

The resulting `define_method` stuff is cutesy, but it provides the common interface `agent.instrument(:name, &block)` to register new instruments, and since passing blocks each time is technically harmless, it makes managing the instruments available to `Agents` nice: just add an element to the `Instruments.types` Hash and require the corresponding `Instrument` class. As a bonus, the Instrument and Agent specs cleaned up nicely, and `rake spec_docs` outputs a very readable outline of those classes and their usage.

The `Calibration` class came about after merging in `Timer`, whose constructor takes an options hash, thus skirting the interface outlined above. After a little thought, the notion of _calibration_ felt like a good fit, especially for instruments such as the `Timer` which utilize other instruments internally. 

With this change, once a Timer is calibrated, it calibrates its Meter similarly, and in particular no longer needs to pass unit information to its Meter, nor to its `scale_duration_ns` method. At first glance, it seems like this sort of configuration representation could be otherwise handy (and also satisfies my linguistic palate).

Anyway, I'm curious to hear what you think.
