### PR TITLE
Have the instruments register themselves

### DIFF
--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -14,7 +14,11 @@ module Metrics
     def self.register_instrument(type, klass)
       @types[type] = klass
     end
-    
+
+    def self.registered_instruments
+      @types
+    end
+
     def self.register_with_options(type, name, options = {})
       @instruments[name] = @types[type].new(options)
     end

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -4,28 +4,16 @@ require File.join(File.dirname(__FILE__), 'statistics', 'sample')
 require File.join(File.dirname(__FILE__), 'statistics', 'uniform_sample')
 require File.join(File.dirname(__FILE__), 'statistics', 'exponential_sample')
 
-require File.join(File.dirname(__FILE__), 'instruments', 'base')
-require File.join(File.dirname(__FILE__), 'instruments', 'counter')
-require File.join(File.dirname(__FILE__), 'instruments', 'meter')
-require File.join(File.dirname(__FILE__), 'instruments', 'gauge')
-require File.join(File.dirname(__FILE__), 'instruments', 'histogram')
-require File.join(File.dirname(__FILE__), 'instruments', 'timer')
-
-
 require 'json'
 
 module Metrics
   module Instruments
     @instruments = {}
-    
-    @types = {
-      :counter                => Counter,
-      :meter                  => Meter,
-      :gauge                  => Gauge,
-      :exponential_histogram  => ExponentialHistogram,
-      :uniform_histogram      => UniformHistogram,
-      :timer                  => Timer
-    }
+    @types = {}
+
+    def self.register_instrument(type, klass)
+      @types[type] = klass
+    end
     
     def self.register_with_options(type, name, options = {})
       @instruments[name] = @types[type].new(options)
@@ -87,3 +75,11 @@ module Metrics
     
   end
 end
+
+require File.join(File.dirname(__FILE__), 'instruments', 'base')
+require File.join(File.dirname(__FILE__), 'instruments', 'counter')
+require File.join(File.dirname(__FILE__), 'instruments', 'meter')
+require File.join(File.dirname(__FILE__), 'instruments', 'gauge')
+require File.join(File.dirname(__FILE__), 'instruments', 'histogram')
+require File.join(File.dirname(__FILE__), 'instruments', 'timer')
+

--- a/lib/ruby-metrics/instruments/counter.rb
+++ b/lib/ruby-metrics/instruments/counter.rb
@@ -29,5 +29,7 @@ module Metrics
       end
       
     end
+
+    register_instrument(:counter, Counter)
   end
 end

--- a/lib/ruby-metrics/instruments/gauge.rb
+++ b/lib/ruby-metrics/instruments/gauge.rb
@@ -16,5 +16,7 @@ module Metrics
       end
       
     end
+
+    register_instrument(:gauge, Gauge)
   end
 end

--- a/lib/ruby-metrics/instruments/histogram.rb
+++ b/lib/ruby-metrics/instruments/histogram.rb
@@ -166,13 +166,16 @@ module Metrics
         super(:exponential)
       end
     end
-  
+
+    register_instrument(:exponential_histogram, ExponentialHistogram)
+
     class UniformHistogram < Histogram
       def initialize
         super(:uniform)
       end
     end
-    
+
+    register_instrument(:uniform_histogram, UniformHistogram)
   end
   
 end

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -93,5 +93,7 @@ module Metrics
       end
       
     end
+
+    register_instrument(:meter, Meter)
   end
 end

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -123,6 +123,8 @@ module Metrics
       end
       
     end
+
+    register_instrument(:timer, Timer)
   end
 end  
       

--- a/spec/instruments_spec.rb
+++ b/spec/instruments_spec.rb
@@ -58,5 +58,19 @@ describe Metrics::Instruments do
     proc = Proc.new { "result" }
     @instruments.register :gauge, :test_gauge, &proc
   end
-    
+
+  context '#register_instrument' do
+    it 'registers a new instrument' do
+      lambda { Metrics::Instruments.register_instrument(:test, String) }.should_not raise_error
+    end
+
+    it 'returns the list of registered instruments' do
+      Metrics::Instruments.register_instrument(:str, String)
+      Metrics::Instruments.register_instrument(:int, Fixnum)
+
+      inst = Metrics::Instruments.registered_instruments
+      inst[:str].should == String
+      inst[:int].should == Fixnum
+    end
+  end
 end


### PR DESCRIPTION
Instead of a static list, this changes the instruments to register them with the main module. This way, if I have a private instrument I want to use in my code I can just register it with the main class and have it accessible through the agent.
