### PR TITLE
Instrument for storing static data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Right now, I have:
 * Gauges
 * Histograms w/ uniform sampling
 * Histograms w/ exponentially decaying sampling
+* Static (storing static data)
  
 Upcoming:
 

--- a/examples/static.rb
+++ b/examples/static.rb
@@ -1,0 +1,24 @@
+require 'rubygems'
+require '../lib/ruby-metrics'
+
+# Specify a port for the agent
+@metrics = Metrics::Agent.new(8081)
+@metrics.start
+
+static = @metrics.static(:data)
+static[:start_time] = Time.now
+static[:status] = :OK
+static[:step] = 0
+
+step = 0
+
+# This is here so that we will run indefinitely so you can hit the 
+# status page on localhost:8081/status
+loop do
+  sleep 1
+
+  static[:step] = step
+  static[:status] = :CRITICAL if step > 10
+  
+  step += 1
+end

--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -10,6 +10,7 @@ require File.join(File.dirname(__FILE__), 'instruments', 'meter')
 require File.join(File.dirname(__FILE__), 'instruments', 'gauge')
 require File.join(File.dirname(__FILE__), 'instruments', 'histogram')
 require File.join(File.dirname(__FILE__), 'instruments', 'timer')
+require File.join(File.dirname(__FILE__), 'instruments', 'static')
 
 
 require 'json'
@@ -24,7 +25,8 @@ module Metrics
       :gauge                  => Gauge,
       :exponential_histogram  => ExponentialHistogram,
       :uniform_histogram      => UniformHistogram,
-      :timer                  => Timer
+      :timer                  => Timer,
+      :static                 => Static
     }
     
     def self.register_with_options(type, name, options = {})
@@ -82,6 +84,10 @@ module Metrics
       
       def exponential_histogram(name)
         register(:exponential_histogram, name)
+      end
+
+      def static(name)
+        register(:static, name)
       end
     end
     

--- a/lib/ruby-metrics/instruments/static.rb
+++ b/lib/ruby-metrics/instruments/static.rb
@@ -1,0 +1,25 @@
+module Metrics
+  module Instruments
+    class Static < Base
+      def initialize
+        @data = {}
+      end
+
+      def []=(key, value)
+        if value
+          @data[key] = value
+        else
+          @data.delete(key)
+        end
+      end
+
+      def [](key)
+        @data[key]
+      end
+
+      def to_s
+        @data.to_json
+      end
+    end
+  end
+end

--- a/spec/instruments/static_spec.rb
+++ b/spec/instruments/static_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Metrics::Instruments::Static do
+  before(:each) do
+    @static = Metrics::Instruments::Static.new
+  end
+  
+  it 'stores and retrieves value' do
+    @static[:foo] = :bar
+    @static[:foo].should == :bar
+  end
+  
+  it "should accurately represent itself using JSON" do
+    @static[:foo] = :bar
+    @static[:now] = '2010-20-11 11:23:40'
+    
+    @static.to_s.should == '{"foo":"bar","now":"2010-20-11 11:23:40"}'
+  end
+end


### PR DESCRIPTION
We often want to serve some extra information from our status endpoints
including things like the process start time, current state, etc. This
is a simple instrument to allow you to save static information and have
the agent serve it from the /status endpoint along with the other
metrics.
