### PR TITLE
Refactor Integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,9 @@ GEM
     diff-lcs (1.1.2)
     json (1.5.1)
     quantity (0.1.1)
+    rack (1.2.2)
+    rack-test (0.5.7)
+      rack (>= 1.0)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
       rspec-expectations (~> 2.5.0)
@@ -27,6 +30,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rack-test
   rspec
   ruby-metrics!
   simplecov (>= 0.3.8)

--- a/README.md
+++ b/README.md
@@ -16,26 +16,68 @@ Right now, I have:
 * Gauges
 * Histograms w/ uniform sampling
 * Histograms w/ exponentially decaying sampling
- 
-Upcoming:
-
-* Timers 
+* Timers
 
 ## Getting Started
 
 The goal of ruby-metrics is to get up and running quickly. You start an agent, register some instruments, and they're exported over HTTP via JSON. For example, getting started with a counter would look like this:
 
     @metrics = Metrics::Agent.new
-    @metrics.start
 
     counter = @metrics.counter :my_counter
     counter.incr
     counter.incr
 
-Then, hitting localhost:8001/status would yield:
+    puts @metrics.to_json
+    #=> {"my_counter":"2"}
 
-    {"my_counter":"2"}
 
+## Integration
+
+Integrating ruby-metrics into existing applications is entirely up to your needs. Provided options include:
+
+* Embedded WEBrick listener:
+
+  This runs a background thread and enables HTTP access to a local port (8001 by default) for a JSON representation of the current metrics.
+
+``` ruby
+require 'ruby-metrics/integration/webrick'
+@agent = Metrics::Agent.new
+@agent.start(:port => 8081)
+```
+
+* Rack Middleware:
+
+  This will add metrics such as `requests` (a timer) as well as counters for each class of HTTP status code (1xx, 2xx, etc). Also counts uncaught exceptions before reraising.
+  Provides a configurable path option (`:show`) to trigger the return of the metrics (as JSON) when the request path matches exactly (a string), as a regular expression, or as any object that responds to `call` for custom logic (passed the whole `env`).
+
+``` ruby
+require 'ruby-metrics'
+@agent = Metrics::Agent.new
+
+use Metrics::Integration::Rack::Middleware, :agent => @agent, :show => '/stats'
+
+run app
+```
+
+* Rack Endpoint:
+
+  Use this to expose an endpoint for external consumption for your metrics.
+  Works best when used with a URLMap or mounted in addition to other routes, like Rails' `mount` route matcher.
+
+``` ruby
+require 'ruby-metrics'
+@agent = Metrics::Agent.new
+
+run Metrics::Integration::Rack::Endpoint.new(:agent => @agent)
+```
+
+or
+
+``` ruby
+# in config/router.rb
+mount Metrics::Integration::Rack::Endpoint.new(:agent => @agent)
+```
 
 [metrics]: https://github.com/codahale/metrics
 

--- a/examples/counter.rb
+++ b/examples/counter.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require '../lib/ruby-metrics'
 
 @metrics = Metrics::Agent.new
-@metrics.start
 
 counter = @metrics.counter :my_counter
 counter.incr

--- a/examples/gauge.rb
+++ b/examples/gauge.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require '../lib/ruby-metrics'
 
 @metrics = Metrics::Agent.new
-@metrics.start
 
 hit_count = 42
 http_requests = 53

--- a/examples/histogram.rb
+++ b/examples/histogram.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require '../lib/ruby-metrics'
+require '../lib/ruby-metrics/integration/webrick'
 
 @metrics = Metrics::Agent.new
 @metrics.start
@@ -16,7 +16,7 @@ end
 step = 0
 
 # This is here so that we will run indefinitely so you can hit the 
-# status page on localhost:8001/status
+# status page on localhost:8001/stats
 loop do
   sleep 1
   

--- a/examples/integration/rack_endpoint.ru
+++ b/examples/integration/rack_endpoint.ru
@@ -1,0 +1,24 @@
+require 'rubygems'
+
+# Ran with:
+# rackup -p 8000 ./examples/integration/rack_endpoint.ru
+# 
+# Make requests to: http://localhost:8000/
+# See stats at    : http://localhost:8000/stats
+
+require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'ruby-metrics')
+@agent = Metrics::Agent.new
+
+counter = @agent.counter(:my_counter)
+
+app = proc do |env|
+  counter.incr
+  [200, {'Content-Type' => 'text/plain'}, ["Counted!"]]
+end
+
+map = Rack::URLMap.new({
+  '/stats'  => Metrics::Integration::Rack::Endpoint.new(:agent => @app),
+  '/'       => app
+})
+
+run map

--- a/examples/integration/rack_middleware.ru
+++ b/examples/integration/rack_middleware.ru
@@ -1,0 +1,21 @@
+require 'rubygems'
+
+# Ran with:
+# rackup -p 8000 ./examples/integration/rack_middleware.ru
+# 
+# Make requests to: http://localhost:8000/
+# See stats at    : http://localhost:8000/stats
+
+require File.join(File.dirname(__FILE__), '..', '..', 'lib', 'ruby-metrics')
+@agent = Metrics::Agent.new
+
+counter = @agent.counter(:my_counter)
+
+use Metrics::Integration::Rack::Middleware, :agent => @agent
+
+app = proc do |env|
+  counter.incr
+  [200, {'Content-Type' => 'text/plain'}, ["Counted!"]]
+end
+
+run app

--- a/examples/integration/webrick.rb
+++ b/examples/integration/webrick.rb
@@ -1,0 +1,17 @@
+require 'rubygems'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib', 'ruby-metrics'))
+
+# Run with:
+# ruby examples/integration/webrick.rb
+
+@agent = Metrics::Agent.new
+
+counter = @agent.counter(:my_counter)
+counter.incr
+counter.incr
+
+Metrics::Integration::WEBrick.start(:port => 8001,
+                                    :agent => @agent)
+
+sleep
+# Now navigate to: http://localhost:8001/stats

--- a/examples/meter.rb
+++ b/examples/meter.rb
@@ -1,9 +1,8 @@
 require 'rubygems'
-require '../lib/ruby-metrics'
+require '../lib/ruby-metrics/integration/webrick'
 
-# Specify a port for the agent
-@metrics = Metrics::Agent.new(8081)
-@metrics.start
+@metrics = Metrics::Agent.new
+@metrics.start :port => 8081 # optional
 
 timer = @metrics.meter :my_meter
 timer.mark(500)
@@ -11,7 +10,7 @@ timer.mark(500)
 step = 0
 
 # This is here so that we will run indefinitely so you can hit the 
-# status page on localhost:8081/status
+# status page on localhost:8081/stats
 loop do
   sleep 1
   

--- a/examples/timer.rb
+++ b/examples/timer.rb
@@ -1,9 +1,8 @@
 require 'rubygems'
-require '../lib/ruby-metrics'
+require '../lib/ruby-metrics/integration/webrick'
 
-# Specify a port for the agent
-@metrics = Metrics::Agent.new(8081)
-@metrics.start
+@metrics = Metrics::Agent.new
+@metrics.start :port => 8081 # optional
 
 timer = @metrics.timer :my_timer
 timer.update(500,   :milliseconds)
@@ -15,7 +14,7 @@ msec_timer = @metrics.timer :msec_timer, {:duration_unit => :microseconds, :rate
 step = 0
 
 # This is here so that we will run indefinitely so you can hit the 
-# status page on localhost:8081/status
+# status page on localhost:8081/stats
 loop do
   sleep 1
   

--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -35,6 +35,10 @@ module Metrics
       @port = port
     end
     
+    def to_json
+      @instruments.to_json
+    end
+    
     def start
       start_daemon_thread
     end

--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -1,5 +1,6 @@
 require File.join(File.dirname(__FILE__), 'logging')
 require File.join(File.dirname(__FILE__), 'instruments')
+require File.join(File.dirname(__FILE__), 'integration')
 require 'webrick'
 
 class Status < WEBrick::HTTPServlet::AbstractServlet

--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -1,27 +1,6 @@
 require File.join(File.dirname(__FILE__), 'logging')
 require File.join(File.dirname(__FILE__), 'instruments')
 require File.join(File.dirname(__FILE__), 'integration')
-require 'webrick'
-
-class Status < WEBrick::HTTPServlet::AbstractServlet
-  
-  def initialize(server, instruments)
-    @instruments = instruments
-  end
-  
-  def do_GET(request, response)
-    status, content_type, body = do_stuff_with(request)
-    
-    response.status = status
-    response['Content-Type'] = content_type
-    response.body = body
-  end
-  
-  def do_stuff_with(request)
-    return 200, "text/plain", @instruments.to_json
-  end
-  
-end
 
 module Metrics
   class Agent
@@ -30,32 +9,14 @@ module Metrics
     
     attr_reader :instruments
     
-    def initialize(port = 8001)
+    def initialize
       logger.debug "Initializing Metrics..."
       @instruments = Metrics::Instruments
-      @port = port
     end
     
     def to_json
       @instruments.to_json
     end
     
-    def start
-      start_daemon_thread
-    end
-    
-    protected
-    def start_daemon_thread(connection_options = {})
-      logger.debug "Creating Metrics daemon thread."
-      @daemon_thread = Thread.new do
-        begin
-          server = WEBrick::HTTPServer.new ({:Port => @port})
-          server.mount "/status", Status, @instruments
-          server.start
-        rescue Exception => e
-          logger.error "Error in worker thread: #{e.class.name}: #{e}\n  #{e.backtrace.join("\n  ")}"
-        end # begin
-      end # thread new
-    end
   end
 end

--- a/lib/ruby-metrics/integration.rb
+++ b/lib/ruby-metrics/integration.rb
@@ -1,6 +1,8 @@
 module Metrics
   module Integration
     
+    autoload :WEBrick, File.join(File.dirname(__FILE__), 'integration', 'webrick')
+    
     module Rack
       autoload :Middleware, File.join(File.dirname(__FILE__), 'integration', 'rack_middleware')
       autoload :Endpoint,   File.join(File.dirname(__FILE__), 'integration', 'rack_endpoint')

--- a/lib/ruby-metrics/integration.rb
+++ b/lib/ruby-metrics/integration.rb
@@ -3,6 +3,7 @@ module Metrics
     
     module Rack
       autoload :Middleware, File.join(File.dirname(__FILE__), 'integration', 'rack_middleware')
+      autoload :Endpoint,   File.join(File.dirname(__FILE__), 'integration', 'rack_endpoint')
     end
     
   end

--- a/lib/ruby-metrics/integration.rb
+++ b/lib/ruby-metrics/integration.rb
@@ -1,0 +1,9 @@
+module Metrics
+  module Integration
+    
+    module Rack
+      autoload :Middleware, File.join(File.dirname(__FILE__), 'integration', 'rack_middleware')
+    end
+    
+  end
+end

--- a/lib/ruby-metrics/integration/rack_endpoint.rb
+++ b/lib/ruby-metrics/integration/rack_endpoint.rb
@@ -1,0 +1,33 @@
+# Provides:
+# * configurable agent
+# * endpoint for accessing metrics JSON
+# 
+module Metrics
+  module Integration
+    module Rack
+      class Endpoint
+        
+        attr_accessor :app, :options, :agent,
+                      # integration metrics
+                      :requests, :uncaught_exceptions,
+                      :status_codes
+        
+        def initialize(options ={})
+          @options  = options
+          @agent    = @options.delete(:agent) || Agent.new
+        end
+        
+        def call(_)
+          body = @agent.to_json
+          
+          [ 200,
+            { 'Content-Type'    => 'application/json',
+              'Content-Length'  => body.size.to_s },
+            [body]
+          ]
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/ruby-metrics/integration/rack_middleware.rb
+++ b/lib/ruby-metrics/integration/rack_middleware.rb
@@ -1,0 +1,82 @@
+# Provides:
+# * configurable agent
+# * configurable endpoint for current metrics
+#   * strings == path_info
+#   * regexp =~ path_info
+#   * proc.call(env) #=> boolean
+# * env['metrics.agent'] upstream
+# * specific metrics by default
+#   * requests (timer)
+#   * uncaught_exceptions (counter)
+#   * response_1xx through response_5xx (counter)
+# 
+module Metrics
+  module Integration
+    module Rack
+      class Middleware
+        
+        attr_accessor :app, :options, :agent,
+                      # integration metrics
+                      :requests, :uncaught_exceptions,
+                      :status_codes
+        
+        def initialize(app, options ={})
+          @app      = app
+          @options  = {:show => "/stats"}.merge(options)
+          @agent    = @options.delete(:agent) || Agent.new
+          
+          # Integration Metrics
+          @requests             = @agent.timer(:_requests)
+          @uncaught_exceptions  = @agent.counter(:_uncaught_exceptions)
+          
+          # HTTP Status Codes
+          @status_codes = {
+            1 => @agent.counter(:_status_1xx),
+            2 => @agent.counter(:_status_2xx),
+            3 => @agent.counter(:_status_3xx),
+            4 => @agent.counter(:_status_4xx),
+            5 => @agent.counter(:_status_5xx)
+          }
+        end
+        
+        def call(env)
+          return show(env) if show?(env)
+          
+          env['metrics.agent'] = @agent
+          
+          status, headers, body = self.requests.time{ @app.call(env) }
+          
+          if status_counter = self.status_codes[status / 100]
+            status_counter.incr
+          end
+          
+          [status, headers, body]
+        rescue Exception
+          # TODO: add "last_uncaught_exception" with string of error
+          self.uncaught_exceptions.incr
+          raise
+        end
+        
+        def show?(env, test = self.options[:show])
+          case
+          when String === test;         env['PATH_INFO'] == test
+          when Regexp === test;         env['PATH_INFO'] =~ test
+          when test.respond_to?(:call); test.call(env)
+          else                          test
+          end
+        end
+        
+        def show(_)
+          body = @agent.to_json
+          
+          [ 200,
+            { 'Content-Type'    => 'application/json',
+              'Content-Length'  => body.size.to_s },
+            [body]
+          ]
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/ruby-metrics/integration/webrick.rb
+++ b/lib/ruby-metrics/integration/webrick.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'ruby-metrics')
+
 require 'webrick'
 
 module Metrics

--- a/lib/ruby-metrics/integration/webrick.rb
+++ b/lib/ruby-metrics/integration/webrick.rb
@@ -1,6 +1,13 @@
 require 'webrick'
 
 module Metrics
+  
+  class Agent
+    def start(options = {})
+      Integration::WEBrick.start(options.merge(:agent => self))
+    end
+  end
+  
   module Integration
     class WEBrick < ::WEBrick::HTTPServlet::AbstractServlet
       include Logging

--- a/lib/ruby-metrics/integration/webrick.rb
+++ b/lib/ruby-metrics/integration/webrick.rb
@@ -1,0 +1,38 @@
+require 'webrick'
+
+module Metrics
+  module Integration
+    class WEBrick < ::WEBrick::HTTPServlet::AbstractServlet
+      include Logging
+      
+      def self.start(options = {})
+        connection_options = {:Port => options.delete(:port) || options.delete(:Port) || 8001}
+        agent = options.delete(:agent) || Agent.new
+        
+        logger.debug "Creating Metrics daemon thread."
+        @thread = Thread.new do
+          begin
+            server = ::WEBrick::HTTPServer.new(connection_options)
+            server.mount "/stats", self, agent
+            server.start
+          rescue Exception => e
+            logger.error "Error in thread: %s: %s\n\t%s" % [e.class.to_s,
+                                                            e.message,
+                                                            e.backtrace.join("\n\t")]
+          end
+        end
+      end
+      
+      def initialize(server, agent)
+        @agent = agent
+      end
+      
+      def do_GET(request, response)
+        response.status           = 200
+        response['Content-Type']  = 'application/json'
+        response.body             = @agent.to_json
+      end
+      
+    end
+  end
+end

--- a/ruby-metrics.gemspec
+++ b/ruby-metrics.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "simplecov", [">= 0.3.8"] #, :require => false
+  s.add_development_dependency "rack-test"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -45,16 +45,4 @@ describe Metrics::Agent do
     @agent.meter(:test_meter).should == @meter
   end
   
-  it "should start the WEBrick daemon" do
-    Thread.stub!(:new).and_return do |block|
-      block.call
-    end
-    
-    mock_server = mock(WEBrick::HTTPServer)
-    WEBrick::HTTPServer.should_receive(:new).and_return mock_server
-    mock_server.should_receive(:mount)
-    mock_server.should_receive(:start)
-    @agent.start
-  end
-    
 end

--- a/spec/integration/rack_endpoint_spec.rb
+++ b/spec/integration/rack_endpoint_spec.rb
@@ -1,0 +1,60 @@
+require "rack/test"
+
+describe Metrics::Integration::Rack::Endpoint do
+  include Rack::Test::Methods
+  
+  def app(options = {})
+    @app ||= Metrics::Integration::Rack::Endpoint.new(options)
+  end
+  def agent
+    app.agent
+  end
+  
+  it "should show stats" do
+    get "/"
+    last_response.should be_ok
+    last_response.body.should == agent.to_json
+  end
+  
+  context "configuring" do
+    
+    context "agent" do
+      it "should create an agent by default" do
+        app(:agent => nil)
+        agent.should be_a(Metrics::Agent)
+      end
+      
+      it "should use an agent if provided" do
+        @agent = Metrics::Agent.new
+        app(:agent => @agent)
+        agent.should be_a(Metrics::Agent)
+        agent.should == @agent
+      end
+    end
+    
+    context "show" do
+      it "should match a string to the PATH_INFO exactly" do
+        app(:show => "/foo")
+        get '/foo'
+        last_response.should be_ok
+        last_response.body.should == agent.to_json
+      end
+      
+      it "should match a regular expression to the PATH_INFO" do
+        app(:show => /bar/)
+        get '/foobarbaz'
+        last_response.should be_ok
+        last_response.body.should == agent.to_json
+      end
+      
+      it "should call `call` on the show option if it responds to it" do
+        app(:show => lambda{ |env| env['PATH_INFO'] == "/bing" })
+        get '/bing'
+        last_response.should be_ok
+        last_response.body.should == agent.to_json
+      end
+    end
+    
+  end
+  
+end

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -1,0 +1,129 @@
+require "rack/test"
+
+describe Metrics::Integration::Rack::Middleware do
+  include Rack::Test::Methods
+  
+  def app(status = 200, body = ["Hello, World!"], headers = {})
+    @app ||= lambda{ |env| [status, {'Content-Type' => 'text/plain', 'Content-Length' => body.to_s.size.to_s}.merge(headers), body] }
+  end
+  alias_method :original_app, :app
+  
+  describe "without integration" do
+    it "should work normally" do
+      get "/"
+      
+      last_response.should be_ok
+      last_response.body.should == "Hello, World!"
+    end
+  end
+  
+  describe "with integration" do
+    def app(options = {})
+      @integrated_app ||= Metrics::Integration::Rack::Middleware.new(original_app, options)
+    end
+    def agent
+      app.agent
+    end
+    
+    it "should work normally" do
+      get "/"
+      
+      last_response.should be_ok
+      last_response.body.should == "Hello, World!"
+    end
+    
+    it "should show stats for default endpoint" do
+      get "/stats"
+      last_response.should be_ok
+      last_response.body.should == agent.to_json
+    end
+    
+    it "should make 'metrics.agent' available to the upstream environment" do
+      @app = lambda do |env|
+        env['metrics.agent'].should be_a(Metrics::Agent)
+        env['metrics.agent'].should == agent
+        [200, {}, []]
+      end
+      
+      get '/'
+      last_response.should be_ok
+    end
+    
+    describe "integration metrics" do
+      
+      it "should count all requests" do
+        lambda do
+          get '/'
+        end.should change{ app.requests.count }.by(1)
+      end
+      
+      it "should count uncaught exceptions" do
+        @app = lambda{ |env| raise }
+        lambda do
+          lambda do
+            get '/'
+          end.should raise_error
+        end.should change{ app.uncaught_exceptions.to_i }.by(1)
+      end
+      
+      it "should time request length" do
+        length = 0.1
+        @app = lambda{ |env| sleep(length); [200, {}, ['']] }
+        get '/'
+        app.requests.mean.should be_within(length / 10).of(length)
+      end
+      
+      [ 200, 304, 404, 500].each do |status|
+        it "should count #{status} HTTP status code as #{status / 100}xx" do
+          @app = lambda{ |env| [status, {}, []] }
+          lambda do
+            get '/'
+          end.should change{ app.status_codes[status / 100].to_i }.by(1)
+        end
+      end
+      
+    end
+    
+    context "configuring" do
+      
+      context "agent" do
+        it "should create an agent by default" do
+          app(:agent => nil)
+          agent.should be_a(Metrics::Agent)
+        end
+        
+        it "should use an agent if provided" do
+          @agent = Metrics::Agent.new
+          app(:agent => @agent)
+          agent.should be_a(Metrics::Agent)
+          agent.should == @agent
+        end
+      end
+      
+      context "show" do
+        it "should match a string to the PATH_INFO exactly" do
+          app(:show => "/foo")
+          get '/foo'
+          last_response.should be_ok
+          last_response.body.should == agent.to_json
+        end
+        
+        it "should match a regular expression to the PATH_INFO" do
+          app(:show => /bar/)
+          get '/foobarbaz'
+          last_response.should be_ok
+          last_response.body.should == agent.to_json
+        end
+        
+        it "should call `call` on the show option if it responds to it" do
+          app(:show => lambda{ |env| env['PATH_INFO'] == "/bing" })
+          get '/bing'
+          last_response.should be_ok
+          last_response.body.should == agent.to_json
+        end
+      end
+      
+    end
+  end
+  
+end

--- a/spec/integration/webrick_spec.rb
+++ b/spec/integration/webrick_spec.rb
@@ -1,0 +1,18 @@
+require "rack/test"
+
+describe Metrics::Integration::WEBrick do
+  
+  it "should start the WEBrick thread" do
+    Thread.stub!(:new).and_return do |block|
+      block.call
+    end
+    
+    mock_server = mock(WEBrick::HTTPServer)
+    WEBrick::HTTPServer.should_receive(:new).and_return mock_server
+    mock_server.should_receive(:mount)
+    mock_server.should_receive(:start)
+    
+    Metrics::Integration::WEBrick.start
+  end
+  
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ end
 $:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'ruby-metrics'
 
+Metrics.logger = Logger.new(STDERR)
+Metrics.logger.level = Logger::INFO
+
 RSpec.configure do |config|
   config.mock_with :rspec
 end


### PR DESCRIPTION
Removes WEBrick by default, making it an optional include, as well as adding options for Rack integration as a middleware or an endpoint.

See the new `examples/integration/*` files as well as the updates `examples/*`.

Includes tests and updated Readme.

Opinion/thought:
It might be a good thing to actually remove any integration options altogether into separate gems. Metrics is useful without any integration options. We probably wont' want to include many more integration options in the canonical gem.

For instance, I want to add some push-based integration: pushing stats to Scout, Munin maybe, and custom consumers.
