### PR TITLE
Metrics::Agent#to_json serializes incorrectly

### DIFF
--- a/lib/ruby-metrics/instruments.rb
+++ b/lib/ruby-metrics/instruments.rb
@@ -36,7 +36,7 @@ module Metrics
     end
     
     def self.to_json
-      @instruments.to_json 
+      @instruments.to_json
     end
     
     module TypeMethods

--- a/lib/ruby-metrics/instruments/base.rb
+++ b/lib/ruby-metrics/instruments/base.rb
@@ -6,8 +6,12 @@ module Metrics
         raise NotImplementedError
       end
       
-      def to_s
+      def to_json(*_)
         raise NotImplementedError
+      end
+      
+      def to_s
+        self.to_json
       end
       
       def to_f

--- a/lib/ruby-metrics/instruments/counter.rb
+++ b/lib/ruby-metrics/instruments/counter.rb
@@ -24,7 +24,7 @@ module Metrics
         @value.to_i
       end
       
-      def to_s
+      def to_json(*_)
         @value.to_s
       end
       

--- a/lib/ruby-metrics/instruments/gauge.rb
+++ b/lib/ruby-metrics/instruments/gauge.rb
@@ -11,7 +11,7 @@ module Metrics
         instance_exec(&@block)
       end
       
-      def to_s
+      def to_json(*_)
         get.to_json
       end
       

--- a/lib/ruby-metrics/instruments/histogram.rb
+++ b/lib/ruby-metrics/instruments/histogram.rb
@@ -149,7 +149,7 @@ module Metrics
         @sample.values
       end
       
-      def to_s
+      def to_json(*_)
         {
           :min => self.min, 
           :max => self.max,

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -84,7 +84,7 @@ module Metrics
         end
       end
       
-      def to_s
+      def to_json(*_)
         {
           :one_minute_rate => self.one_minute_rate,
           :five_minute_rate => self.five_minute_rate,

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -98,7 +98,7 @@ module Metrics
         end
       end
       
-      def to_s
+      def to_json(*_)
         {
           :count => self.count,
           :rates => {

--- a/spec/instruments/base_spec.rb
+++ b/spec/instruments/base_spec.rb
@@ -5,7 +5,7 @@ describe Metrics::Instruments::Base do
     @base = Metrics::Instruments::Base.new
   end
   
-  %w( to_i to_f to_s ).each do |method|
+  %w( to_i to_f to_json to_s ).each do |method|
     it "should raise a NotImplementedError for ##{method}" do
       lambda do
         @base.send(method)

--- a/spec/instruments/counter_spec.rb
+++ b/spec/instruments/counter_spec.rb
@@ -69,4 +69,11 @@ describe Metrics::Instruments::Counter do
     end.should change{ @counter.to_i }.by(-1)
   end
   
+  context "to_json" do
+    let(:json) { @counter.to_json }
+    it "should serialize to its current value" do
+      json.should == @counter.to_s
+    end
+  end
+  
 end

--- a/spec/instruments/gauge_spec.rb
+++ b/spec/instruments/gauge_spec.rb
@@ -27,18 +27,16 @@ describe Metrics::Instruments::Gauge do
     @gauge.get[:result].should == 43
   end
   
-  it "should JSONify the results when you call to_s" do
-    result = 42
-    
-    callback = Proc.new do 
-      {
-        :result => result
-      }
+  context "to_json" do
+    it "should serialize the current value" do
+      result = 0
+      gauge = Metrics::Instruments::Gauge.new{ result }
+      
+      gauge.to_json.should == result.to_s
+      
+      result = 2
+      gauge.to_json.should == result.to_s
     end
-    
-    @gauge = Metrics::Instruments::Gauge.new &callback
-    
-    @gauge.to_s.should == "{\"result\":42}"
   end
   
 end

--- a/spec/instruments/histogram_spec.rb
+++ b/spec/instruments/histogram_spec.rb
@@ -39,10 +39,6 @@ describe Metrics::Instruments::Histogram do
       @histogram.mean.should == 3.4877830882352936
     end
   
-    it "should accurately represent itself using JSON" do
-      @histogram.to_s.should == "{\"min\":1.6,\"max\":5.1,\"mean\":3.4877830882352936,\"variance\":1.3027283328494685,\"percentiles\":{\"0.25\":2.16275,\"0.5\":4.0,\"0.75\":4.45425,\"0.95\":4.817,\"0.97\":4.8977900000000005,\"0.98\":4.933,\"0.99\":5.009570000000001}}"
-    end
-  
     it "should return correct values for mean, std. deviation and variance when no elements are in the histogram" do
       histogram = Metrics::Instruments::Histogram.new
       histogram.variance.should == 0.0
@@ -94,6 +90,26 @@ describe Metrics::Instruments::Histogram do
       histogram.mean.should == 0.0
       histogram.std_dev.should == 0.0
     end
+  end
+  
+  context "to_json" do
+    before(:each) do
+      @histogram  = Metrics::Instruments::Histogram.new
+      @hash       = JSON.parse(@histogram.to_json)
+    end
+    
+    %w( min max mean variance ).each do |attr|
+      it "should serialize with the #{attr} value" do
+        @hash[attr].should_not be_nil
+      end
+    end
+    
+    %w( 0.25 0.5 0.75 0.95 0.97 0.98 0.99 ).each do |percentile|
+      it "should have the #{percentile} percentile" do
+        @hash["percentiles"][percentile].should_not be_nil
+      end
+    end
+    
   end
   
 end

--- a/spec/instruments/meter_spec.rb
+++ b/spec/instruments/meter_spec.rb
@@ -81,6 +81,19 @@ describe Metrics::Instruments::Meter do
     end
   
   end
+  
+  context "to_json" do
+    before(:each) do
+      @meter  = Metrics::Instruments::Meter.new
+      @hash   = JSON.parse(@meter.to_json)
+    end
     
+    %w( one_minute_rate five_minute_rate fifteen_minute_rate ).each do |attr|
+      it "should serialize with the #{attr} value" do
+        @hash[attr].should_not be_nil
+      end
+    end
+    
+  end
   
 end

--- a/spec/instruments/timer_spec.rb
+++ b/spec/instruments/timer_spec.rb
@@ -92,9 +92,6 @@ describe Metrics::Instruments::Timer do
       @timer.values.sort.should == [10, 20, 20, 30, 40]
     end
     
-    it "should accurately represent itself using JSON" do
-      @timer.to_s.should == "{\"count\":5,\"rates\":{\"one_minute_rate\":0.0,\"five_minute_rate\":0.0,\"fifteen_minute_rate\":0.0,\"unit\":\"seconds\"},\"durations\":{\"min\":10.0,\"max\":40.0,\"mean\":24.0,\"percentiles\":{\"0.25\":20.0,\"0.5\":20.0,\"0.75\":30.0,\"0.95\":38.0,\"0.97\":38.8,\"0.98\":39.2,\"0.99\":39.6},\"unit\":\"milliseconds\"}}"
-    end
   end
   
   context "Timing blocks of code" do
@@ -114,6 +111,36 @@ describe Metrics::Instruments::Timer do
       @timer.max.should <= 300000000
 
     end
+  end
+  
+  context "to_json" do
+    before(:each) do
+      @timer  = Metrics::Instruments::Timer.new
+      @hash   = JSON.parse(@timer.to_json)
+    end
+    
+    it "should serialize with the count value" do
+      @hash["count"].should_not be_nil
+    end
+    
+    %w( one_minute_rate five_minute_rate fifteen_minute_rate ).each do |rate|
+      it "should serialize with the #{rate} rate" do
+        @hash["rates"][rate].should_not be_nil
+      end
+    end
+    
+    %w( min max mean ).each do |duration|
+      it "should serialize with the #{duration} duration" do
+        @hash["durations"][duration].should_not be_nil
+      end
+    end
+    
+    %w( 0.25 0.5 0.75 0.95 0.97 0.98 0.99 ).each do |percentile|
+      it "should serialize with the #{percentile} duration percentile" do
+        @hash["durations"]["percentiles"][percentile].should_not be_nil
+      end
+    end
+    
   end
   
 end

--- a/spec/instruments_spec.rb
+++ b/spec/instruments_spec.rb
@@ -45,7 +45,7 @@ describe Metrics::Instruments do
     @instruments.register(:meter, :test_meter).should == @meter
     @instruments.registered.should == {:test_meter => @meter}
     
-    @instruments.to_json.should == "{\"test_meter\":\"{\\\"one_minute_rate\\\":0.0,\\\"five_minute_rate\\\":0.0,\\\"fifteen_minute_rate\\\":0.0}\"}"
+    @instruments.to_json.should == %({"test_meter":{"one_minute_rate":0.0,"five_minute_rate":0.0,"fifteen_minute_rate":0.0}})
   end
   
   it "should not allow for creating a gauge with no block" do 


### PR DESCRIPTION
I've seen some problems serializing the metrics to JSON. For example:

``` ruby
a = Metrics::Agent.new
c = a.counter :test
a.to_json #=> "{\"test\":{\"value\":0}}"
c.to_json #=> "{\"test\":0}"
```

Ultimately it's probably because we just need to define `to_json` on objects instead of `to_s`.

I'll write tests and a pull request for this. About to present on it... ;)
