### PR TITLE
Fix for compatibility with ActiveSupport JSON generation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (3.0.8)
     diff-lcs (1.1.2)
     json (1.5.1)
     rack (1.2.2)
@@ -28,6 +29,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   rack-test
   rspec
   ruby-metrics!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
   specs:
     activesupport (3.0.8)
     diff-lcs (1.1.2)
+    i18n (0.6.0)
     json (1.5.1)
     rack (1.2.2)
     rack-test (0.5.7)
@@ -30,6 +31,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  i18n
   rack-test
   rspec
   ruby-metrics!

--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,12 @@ RSpec::Core::RakeTask.new do |t|
   t.pattern = 'spec/**/*_spec.rb'
 end
 
+namespace :spec do
+  RSpec::Core::RakeTask.new do |t|
+    t.name = :activesupport
+    t.rspec_opts = ["-c", "-f progress", "-r ./spec/spec_helper.rb -r active_support -r active_support/json"]
+    t.pattern = 'spec/**/*_spec.rb'
+  end
+end
+
 task :default => :spec

--- a/lib/ruby-metrics/instruments/base.rb
+++ b/lib/ruby-metrics/instruments/base.rb
@@ -6,8 +6,12 @@ module Metrics
         raise NotImplementedError
       end
       
-      def to_json(*_)
+      def as_json(*_)
         raise NotImplementedError
+      end
+      
+      def to_json(*_)
+        self.as_json.to_json
       end
       
       def to_s

--- a/lib/ruby-metrics/instruments/counter.rb
+++ b/lib/ruby-metrics/instruments/counter.rb
@@ -24,10 +24,10 @@ module Metrics
         @value.to_i
       end
       
-      def to_json(*_)
-        @value.to_s
+      def as_json(*_)
+        @value
       end
-      
+
     end
 
     register_instrument(:counter, Counter)

--- a/lib/ruby-metrics/instruments/gauge.rb
+++ b/lib/ruby-metrics/instruments/gauge.rb
@@ -11,8 +11,8 @@ module Metrics
         instance_exec(&@block)
       end
       
-      def to_json(*_)
-        get.to_json
+      def as_json(*_)
+        get
       end
       
     end

--- a/lib/ruby-metrics/instruments/histogram.rb
+++ b/lib/ruby-metrics/instruments/histogram.rb
@@ -149,14 +149,14 @@ module Metrics
         @sample.values
       end
       
-      def to_json(*_)
+      def as_json(*_)
         {
           :min => self.min, 
           :max => self.max,
           :mean => self.mean, 
           :variance => self.variance, 
           :percentiles => self.quantiles([0.25, 0.50, 0.75, 0.95, 0.97, 0.98, 0.99])
-        }.to_json
+        }
       end
     
     end

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -84,12 +84,12 @@ module Metrics
         end
       end
       
-      def to_json(*_)
+      def as_json(*_)
         {
           :one_minute_rate => self.one_minute_rate,
           :five_minute_rate => self.five_minute_rate,
           :fifteen_minute_rate => self.fifteen_minute_rate
-        }.to_json
+        }
       end
       
     end

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -98,7 +98,7 @@ module Metrics
         end
       end
       
-      def to_json(*_)
+      def as_json(*_)
         {
           :count => self.count,
           :rates => {
@@ -114,7 +114,7 @@ module Metrics
             :percentiles => self.quantiles([0.25, 0.50, 0.75, 0.95, 0.97, 0.98, 0.99]),
             :unit => @duration_unit
           }
-        }.to_json
+        }
       end
       
       private

--- a/ruby-metrics.gemspec
+++ b/ruby-metrics.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov", [">= 0.3.8"] #, :require => false
   s.add_development_dependency "rack-test"
   s.add_development_dependency "activesupport"
+  s.add_development_dependency "i18n"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/ruby-metrics.gemspec
+++ b/ruby-metrics.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "simplecov", [">= 0.3.8"] #, :require => false
   s.add_development_dependency "rack-test"
+  s.add_development_dependency "activesupport"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -44,5 +44,20 @@ describe Metrics::Agent do
 
     @agent.meter(:test_meter).should == @meter
   end
+
+  it "should add a timer instrument correctly" do
+    @meter = Metrics::Instruments::Timer.new
+    Metrics::Instruments::Timer.stub!(:new).and_return @timer
+
+    @agent.timer(:test_timer).should == @timer
+  end
+
+  it "should serialize a timer instrument correctly" do
+    @agent.timer(:test_timer)
+    @hash = JSON.parse(@agent.to_json)
+    @hash["test_timer"].should_not be_nil
+    @hash["test_timer"]["count"].should_not be_nil
+    @hash["test_timer"]["count"].should == 0
+  end
   
 end

--- a/spec/instruments_spec.rb
+++ b/spec/instruments_spec.rb
@@ -40,12 +40,20 @@ describe Metrics::Instruments do
   end
 
   
-  it "should generate JSON correctly" do 
+  it "should generate JSON for a Meter correctly" do 
     Metrics::Instruments::Meter.stub!(:new).and_return @meter
     @instruments.register(:meter, :test_meter).should == @meter
     @instruments.registered.should == {:test_meter => @meter}
     
     @instruments.to_json.should == %({"test_meter":{"one_minute_rate":0.0,"five_minute_rate":0.0,"fifteen_minute_rate":0.0}})
+  end
+  
+  it "should generate JSON for a Counter correctly" do 
+    Metrics::Instruments::Counter.stub!(:new).and_return @counter
+    @instruments.register(:counter, :test_counter).should == @counter
+    @instruments.registered.should == {:test_counter => @counter}
+    
+    @instruments.to_json.should == %({"test_counter":0})
   end
   
   it "should not allow for creating a gauge with no block" do 

--- a/spec/instruments_spec.rb
+++ b/spec/instruments_spec.rb
@@ -55,6 +55,22 @@ describe Metrics::Instruments do
     
     @instruments.to_json.should == %({"test_counter":0})
   end
+
+  it "should generate JSON for a Gauge correctly" do
+    val = 3
+    @instruments.register(:gauge, :test_gauge) { val }
+    @instruments.to_json.should == %({"test_gauge":3})
+  end
+  
+  it "should generate JSON for a Histogram correctly" do
+    @instruments.register(:exponential_histogram, :test_histogram)
+    @instruments.to_json.should == %({"test_histogram":{"min":0.0,"max":0.0,"mean":0.0,"variance":0.0,"percentiles":{"0.25":0.0,"0.5":0.0,"0.75":0.0,"0.95":0.0,"0.97":0.0,"0.98":0.0,"0.99":0.0}}})
+  end
+  
+  it "should generate JSON for a Timer correctly" do
+    @instruments.register(:timer, :test_timer)
+    @instruments.to_json.should == %({"test_timer":{"count":0,"rates":{"one_minute_rate":0.0,"five_minute_rate":0.0,"fifteen_minute_rate":0.0,"unit":"seconds"},"durations":{"min":0.0,"max":0.0,"mean":0.0,"percentiles":{"0.25":0.0,"0.5":0.0,"0.75":0.0,"0.95":0.0,"0.97":0.0,"0.98":0.0,"0.99":0.0},"unit":"seconds"}}})
+  end
   
   it "should not allow for creating a gauge with no block" do 
     lambda do

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -81,7 +81,21 @@ describe Metrics::Integration::Rack::Middleware do
           end.should change{ app.status_codes[status / 100].to_i }.by(1)
         end
       end
-      
+
+      it "should build timer JSON properly" do
+        agent_h = JSON.parse(agent.to_json)
+        agent_h["_requests"].should_not be_nil
+        agent_h["_requests"]["count"].should == app.requests.count
+      end
+
+      it "should serve timer JSON properly" do
+        get "/stats"
+        agent_j = last_response.body
+        h = JSON.parse(agent_j)
+        h["_requests"].should_not be_nil
+        h["_requests"]["count"].should == app.requests.count
+      end
+
     end
     
     context "configuring" do


### PR DESCRIPTION
When trying to use ruby-metrics in a real application, I found that ActiveSupport's JSON support overrides things like Hash#to_json in a way that breaks JSON rendering of instruments. As a result, I wasn't getting useful output from the Rack middleware component's /stats URI.

This branch adds a Rake task, spec:activesupport, to run all the tests with ActiveSupport and its JSON handling loaded; some tests to illustrate the problem for all the instruments; and a slight change to the to_json implementation to work in a way that's compatible with ActiveSupport.

It does not add a runtime dependency on ActiveSupport, and the tests still pass without ActiveSupport loaded. For the moment, "rake spec" and "rake spec:activesupport" have to be run separately, but perhaps they should be combined.
