### PR TITLE
Squash warning about putting a space before argument parentheses

### DIFF
--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -23,7 +23,7 @@ module Metrics
 
       def update(duration, unit)
         mult = convert_to_ns(1, unit)
-        self.update_timer (duration * mult)
+        self.update_timer(duration * mult)
       end
 
       def time(&block) 


### PR DESCRIPTION
```
/Users/alindeman/.rvm/gems/ruby-1.8.7-p334/gems/ruby-metrics-0.8.6/lib/ruby-metrics/instruments/timer.rb:26: warning: don't put space before argument parentheses
```
