### PR TITLE
Implement #as_json on all objects

### DIFF
--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -51,8 +51,12 @@ module Metrics
       @instruments[name] ||= Instruments::ExponentialHistogram.new
     end
 
-    def to_json
-      @instruments.to_json
+    def as_json(*_)
+      @instruments
+    end
+
+    def to_json(*_)
+      as_json.to_json
     end
   end
 end

--- a/lib/ruby-metrics/instruments/counter.rb
+++ b/lib/ruby-metrics/instruments/counter.rb
@@ -27,8 +27,12 @@ module Metrics
         @value.to_s
       end
 
+      def as_json(*_)
+        @value
+      end
+
       def to_json(*_)
-        @value.to_json
+        as_json.to_json
       end
     end
   end

--- a/lib/ruby-metrics/instruments/gauge.rb
+++ b/lib/ruby-metrics/instruments/gauge.rb
@@ -10,9 +10,13 @@ module Metrics
         instance_exec(&@block)
       end
 
-      def to_json(*_)
+      def as_json(*_)
         value = get
-        value.respond_to?(:to_json) ? value.to_json : value
+        value.respond_to?(:as_json) ? value.as_json : value
+      end
+
+      def to_json(*_)
+        as_json.to_json
       end
     end
   end

--- a/lib/ruby-metrics/instruments/histogram.rb
+++ b/lib/ruby-metrics/instruments/histogram.rb
@@ -152,14 +152,18 @@ module Metrics
         @sample.values
       end
 
-      def to_json(*_)
+      def as_json(*_)
         {
           :min => self.min,
           :max => self.max,
           :mean => self.mean,
           :variance => self.variance,
           :percentiles => self.quantiles([0.25, 0.50, 0.75, 0.95, 0.97, 0.98, 0.99])
-        }.to_json
+        }
+      end
+
+      def to_json(*_)
+        as_json.to_json
       end
     end
 

--- a/lib/ruby-metrics/instruments/meter.rb
+++ b/lib/ruby-metrics/instruments/meter.rb
@@ -83,12 +83,16 @@ module Metrics
         end
       end
 
-      def to_json(*_)
+      def as_json(*_)
         {
           :one_minute_rate => self.one_minute_rate,
           :five_minute_rate => self.five_minute_rate,
           :fifteen_minute_rate => self.fifteen_minute_rate
-        }.to_json
+        }
+      end
+
+      def to_json(*_)
+        as_json.to_json
       end
     end
   end

--- a/lib/ruby-metrics/instruments/timer.rb
+++ b/lib/ruby-metrics/instruments/timer.rb
@@ -98,7 +98,7 @@ module Metrics
         end
       end
 
-      def to_json(*_)
+      def as_json(*_)
         {
           :count => count,
           :rates => {
@@ -114,7 +114,11 @@ module Metrics
             :percentiles => quantiles([0.25, 0.50, 0.75, 0.95, 0.97, 0.98, 0.99]),
             :unit => @duration_unit
           }
-        }.to_json
+        }
+      end
+
+      def to_json(*_)
+        as_json.to_json
       end
 
       private


### PR DESCRIPTION
Delegate generation of json hash to #as_json and update #to_json to call
the new method.

This follows the ActiveSupport convention for separating actual JSON
generation from creating a hash to represent the data.

This pull request implements the remaining work that was in #25.
