### PR TITLE
Prevent exception taking down app

### DIFF
--- a/lib/ruby-metrics/statistics/exponential_sample.rb
+++ b/lib/ruby-metrics/statistics/exponential_sample.rb
@@ -37,7 +37,7 @@ module Metrics
           @values[priority] = value
         else
           firstkey = @values.keys[0]
-          if (firstkey < priority)
+          if firstkey && (firstkey < priority)
             @values[priority] = value
             
             while(@values.delete(firstkey) == nil)


### PR DESCRIPTION
I'll prefix this with the I've only recreated this issue in a hello world rack application and under JRuby and under high load.

Specifically this Rack application https://github.com/garethr/jruby-embedded-jetty, running under JRuby with an embedded Jetty web server. Plus the Rack middleware from ruby-metrics.

Everything works fine until the following exception occurs, at which point all future requests will also fail with the same exception.

```
Application Error
org.jruby.exceptions.RaiseException: (NoMethodError) undefined method `<' for nil:NilClass
    at Metrics::Statistics::ExponentialSample.update_with_timestamp(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/statistics/exponential_sample.rb:41)
    at Metrics::Statistics::ExponentialSample.update(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/statistics/exponential_sample.rb:30)
    at Metrics::Instruments::Histogram.update(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/instruments/histogram.rb:23)
    at Metrics::Instruments::Timer.update_timer(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/instruments/timer.rb:96)
    at Metrics::Instruments::Timer.time(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/instruments/timer.rb:34)
    at Metrics::Integration::Rack::Middleware.call(/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/gems/gems/ruby-metrics-0.8.6/lib/ruby-metrics/integration/rack_middleware.rb:47)
    at Rack::Handler::Servlet.call(file:/private/var/folders/hc/7z0ng7n13xd969fg38qtfdbc0000gn/T/warbler3637608734258569271webroot/jruby-embedded-jetty.war/work/jetty-0.0.0.0-8090-jruby-embedded-jetty.war-_-any-/webapp/WEB-INF/lib/gems-gems-jruby-rack-1.1.5-lib-jruby-rack-1.1.5.jar!/rack/handler/servlet.rb:21)
```

I've only been able to trigger this as mentioned under a bit of load, for instance running locally with ab -c 50 -n 10000. But it demonstrates the problem. 

I'm not sure a problem with metrics collection should be able to bring down the entire rest of the stack.

But I'm also not sure the patch attached is the right one, although it does appear to resolve the problem. Interested in any thoughts.
