### PR TITLE
Don't pass units to Instruments::UniformHistogram

### DIFF
--- a/lib/ruby-metrics/agent.rb
+++ b/lib/ruby-metrics/agent.rb
@@ -43,7 +43,7 @@ module Metrics
     end
 
     def uniform_histogram(name, units = "")
-      @instruments[name] ||= Instruments::UniformHistogram.new(:units => units)
+      @instruments[name] ||= Instruments::UniformHistogram.new
     end
 
     # For backwards compatibility


### PR DESCRIPTION
The UniformHistogram isn't prepared to receive units at this time, so don't send them.
